### PR TITLE
escape characters and string interpolation

### DIFF
--- a/themes/SmoothYellowTheme.tmTheme
+++ b/themes/SmoothYellowTheme.tmTheme
@@ -87,7 +87,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#B4C2D6</string>
+				<string>#D6C5B4</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Different color for escape characters and string interpolation
Python example
![image](https://user-images.githubusercontent.com/7345761/33116308-593c9c7c-cf75-11e7-848c-3800dec94bf6.png)
